### PR TITLE
Rename Dest8Bit to Register8Bit

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -17,7 +17,7 @@
     with garlicjr. If not, see <https: //www.gnu.org/licenses/>.
 */
 
-use crate::opcode::{Dest8Bit, Opcode};
+use crate::opcode::{Register8Bit, Opcode};
 use crate::{Bus, ReadWriteMode};
 
 pub struct SharpSM83 {
@@ -96,7 +96,7 @@ impl SharpSM83 {
         self.current_tick = 0;
     }
 
-    fn ld_r_n8(&mut self, destination: Dest8Bit, bus: &mut Bus) {
+    fn ld_r_n8(&mut self, destination: Register8Bit, bus: &mut Bus) {
         match self.current_tick {
             5 => {
                 bus.mode = ReadWriteMode::Read;
@@ -111,15 +111,15 @@ impl SharpSM83 {
         }
     }
 
-    fn write_to_register(&mut self, dest: Dest8Bit, data: u8) {
+    fn write_to_register(&mut self, dest: Register8Bit, data: u8) {
         match dest {
-            Dest8Bit::A => self.registers.a = data,
-            Dest8Bit::B => self.registers.b = data,
-            Dest8Bit::C => self.registers.c = data,
-            Dest8Bit::D => self.registers.d = data,
-            Dest8Bit::E => self.registers.e = data,
-            Dest8Bit::H => self.registers.h = data,
-            Dest8Bit::L => self.registers.l = data,
+            Register8Bit::A => self.registers.a = data,
+            Register8Bit::B => self.registers.b = data,
+            Register8Bit::C => self.registers.c = data,
+            Register8Bit::D => self.registers.d = data,
+            Register8Bit::E => self.registers.e = data,
+            Register8Bit::H => self.registers.h = data,
+            Register8Bit::L => self.registers.l = data,
             _ => panic!("Tried to write to invalid destination"),
         };
     }
@@ -131,7 +131,7 @@ mod tests {
 
     use super::*;
 
-    use crate::{opcode::Dest8Bit, ReadWriteMode};
+    use crate::{opcode::Register8Bit, ReadWriteMode};
 
     #[test]
     fn should_return_true_when_register_contents_are_the_same() {
@@ -368,15 +368,15 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Dest8Bit::A, 0b00111110)]
-    #[case(Dest8Bit::B, 0b00000110)]
-    #[case(Dest8Bit::C, 0b00001110)]
-    #[case(Dest8Bit::D, 0b00010110)]
-    #[case(Dest8Bit::E, 0b00011110)]
-    #[case(Dest8Bit::H, 0b00100110)]
-    #[case(Dest8Bit::L, 0b00101110)]
+    #[case(Register8Bit::A, 0b00111110)]
+    #[case(Register8Bit::B, 0b00000110)]
+    #[case(Register8Bit::C, 0b00001110)]
+    #[case(Register8Bit::D, 0b00010110)]
+    #[case(Register8Bit::E, 0b00011110)]
+    #[case(Register8Bit::H, 0b00100110)]
+    #[case(Register8Bit::L, 0b00101110)]
     fn should_load_into_given_register_on_tick_8_of_ld_r_n8(
-        #[case] destination: Dest8Bit,
+        #[case] destination: Register8Bit,
         #[case] opcode: u8,
     ) {
         let mut cpu = SharpSM83::new();
@@ -402,13 +402,13 @@ mod tests {
         cpu.tick(&mut bus);
 
         let destination_map = vec![
-            (Dest8Bit::A, cpu.registers.a, registers_before.a),
-            (Dest8Bit::B, cpu.registers.b, registers_before.b),
-            (Dest8Bit::C, cpu.registers.c, registers_before.c),
-            (Dest8Bit::D, cpu.registers.d, registers_before.d),
-            (Dest8Bit::E, cpu.registers.e, registers_before.e),
-            (Dest8Bit::H, cpu.registers.h, registers_before.h),
-            (Dest8Bit::L, cpu.registers.l, registers_before.l),
+            (Register8Bit::A, cpu.registers.a, registers_before.a),
+            (Register8Bit::B, cpu.registers.b, registers_before.b),
+            (Register8Bit::C, cpu.registers.c, registers_before.c),
+            (Register8Bit::D, cpu.registers.d, registers_before.d),
+            (Register8Bit::E, cpu.registers.e, registers_before.e),
+            (Register8Bit::H, cpu.registers.h, registers_before.h),
+            (Register8Bit::L, cpu.registers.l, registers_before.l),
         ];
 
         destination_map

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -21,7 +21,7 @@
 #[allow(dead_code)]
 pub enum Opcode {
     NOP,
-    LDRI8(Dest8Bit),
+    LDRI8(Register8Bit),
     LdR8HLAddr,
     Unimplemented(u8),
 }
@@ -39,8 +39,8 @@ impl Opcode {
         match (top_2, bot_3) {
             (0b00000000, 0b00000110) => {
                 let reg_num = (data & 0b00111000) >> 3;
-                let register = Dest8Bit::from_u8(reg_num);
-                if register == Dest8Bit::HLAddr {
+                let register = Register8Bit::from_u8(reg_num);
+                if register == Register8Bit::HLAddr {
                     Opcode::LdR8HLAddr
                 } else {
                     Opcode::LDRI8(register)
@@ -52,7 +52,7 @@ impl Opcode {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub enum Dest8Bit {
+pub enum Register8Bit {
     A,
     B,
     C,
@@ -63,17 +63,17 @@ pub enum Dest8Bit {
     HLAddr,
 }
 
-impl Dest8Bit {
-    pub fn from_u8(data: u8) -> Dest8Bit {
+impl Register8Bit {
+    pub fn from_u8(data: u8) -> Register8Bit {
         match data {
-            0 => Dest8Bit::B,
-            1 => Dest8Bit::C,
-            2 => Dest8Bit::D,
-            3 => Dest8Bit::E,
-            4 => Dest8Bit::H,
-            5 => Dest8Bit::L,
-            6 => Dest8Bit::HLAddr,
-            7 => Dest8Bit::A,
+            0 => Register8Bit::B,
+            1 => Register8Bit::C,
+            2 => Register8Bit::D,
+            3 => Register8Bit::E,
+            4 => Register8Bit::H,
+            5 => Register8Bit::L,
+            6 => Register8Bit::HLAddr,
+            7 => Register8Bit::A,
             _ => panic!("Invalid register"),
         }
     }
@@ -115,15 +115,15 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Dest8Bit::A, 0b00111110)]
-    #[case(Dest8Bit::B, 0b00000110)]
-    #[case(Dest8Bit::C, 0b00001110)]
-    #[case(Dest8Bit::D, 0b00010110)]
-    #[case(Dest8Bit::E, 0b00011110)]
-    #[case(Dest8Bit::H, 0b00100110)]
-    #[case(Dest8Bit::L, 0b00101110)]
+    #[case(Register8Bit::A, 0b00111110)]
+    #[case(Register8Bit::B, 0b00000110)]
+    #[case(Register8Bit::C, 0b00001110)]
+    #[case(Register8Bit::D, 0b00010110)]
+    #[case(Register8Bit::E, 0b00011110)]
+    #[case(Register8Bit::H, 0b00100110)]
+    #[case(Register8Bit::L, 0b00101110)]
     fn should_return_ldri8_containing_destination_given_00xxx110(
-        #[case] destination: Dest8Bit,
+        #[case] destination: Register8Bit,
         #[case] raw_opcode: u8,
     ) {
         let opcode = Opcode::decode(raw_opcode);
@@ -138,49 +138,49 @@ mod tests {
 
     #[test]
     fn should_return_b_when_given_0() {
-        let register = Dest8Bit::from_u8(0);
-        assert_eq!(register, Dest8Bit::B);
+        let register = Register8Bit::from_u8(0);
+        assert_eq!(register, Register8Bit::B);
     }
 
     #[test]
     fn should_return_c_when_given_1() {
-        let register = Dest8Bit::from_u8(1);
-        assert_eq!(register, Dest8Bit::C);
+        let register = Register8Bit::from_u8(1);
+        assert_eq!(register, Register8Bit::C);
     }
 
     #[test]
     fn should_return_d_when_given_2() {
-        let register = Dest8Bit::from_u8(2);
-        assert_eq!(register, Dest8Bit::D);
+        let register = Register8Bit::from_u8(2);
+        assert_eq!(register, Register8Bit::D);
     }
 
     #[test]
     fn should_return_e_when_given_3() {
-        let register = Dest8Bit::from_u8(3);
-        assert_eq!(register, Dest8Bit::E);
+        let register = Register8Bit::from_u8(3);
+        assert_eq!(register, Register8Bit::E);
     }
 
     #[test]
     fn should_return_h_when_given_4() {
-        let register = Dest8Bit::from_u8(4);
-        assert_eq!(register, Dest8Bit::H);
+        let register = Register8Bit::from_u8(4);
+        assert_eq!(register, Register8Bit::H);
     }
 
     #[test]
     fn should_return_l_when_given_5() {
-        let register = Dest8Bit::from_u8(5);
-        assert_eq!(register, Dest8Bit::L);
+        let register = Register8Bit::from_u8(5);
+        assert_eq!(register, Register8Bit::L);
     }
 
     #[test]
     fn should_return_hladdr_when_given_6() {
-        let register = Dest8Bit::from_u8(6);
-        assert_eq!(register, Dest8Bit::HLAddr);
+        let register = Register8Bit::from_u8(6);
+        assert_eq!(register, Register8Bit::HLAddr);
     }
 
     #[test]
     fn should_return_a_when_given_7() {
-        let register = Dest8Bit::from_u8(7);
-        assert_eq!(register, Dest8Bit::A);
+        let register = Register8Bit::from_u8(7);
+        assert_eq!(register, Register8Bit::A);
     }
 }


### PR DESCRIPTION
The new name allows us to reuse Register8Bit for both source and destination registers. Register is a slight misnomer, since [HL] is also a valid "register", but I cannot think of a better name.